### PR TITLE
Don't assume what server.match returns

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ exports.register = function (server, options, next) {
 
         const route = server.match(request.method, versionedPath);
 
-        if (route) {
+        if (route && route.path === versionedPath) {
             request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
         }
 


### PR DESCRIPTION
`server.match()` (or `connection.match()`) returns a matching route which doesn't have to be what you searched for. When serving static files for example, it's common to have a route like `/{files*}` which is a catch-all when other matches fail.

If you have defined `/foo` and `/{files*}` and  try to match `/v1/foo` then `.match` will actually return `/{files*}` which is the last possible match. So you shouldn't assume a non-null result is the route you searched for.