### PR TITLE
Support path parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,16 @@ const _extractVersionFromAcceptHeader = function (request, options) {
     return null;
 };
 
+//Checks if server.match returns expected versioned route
+const _isRouteVersioned = function (route, versionedPath) {
+
+    const fingerprint = route ? route.fingerprint : '';
+    const fingerprintItems = fingerprint.split('/'); //Split to account for path parameters
+    const versionedPathItems = versionedPath.split('/'); //Split to account for path parameters
+
+    return fingerprintItems.length === versionedPathItems.length;
+};
+
 exports.register = function (server, options, next) {
 
     const validateOptions = internals.optionsSchema.validate(options);
@@ -82,7 +92,9 @@ exports.register = function (server, options, next) {
 
         const route = server.match(request.method, versionedPath);
 
-        if (route && route.path === versionedPath) {
+        const validMatch = _isRouteVersioned(route, versionedPath);
+
+        if (validMatch) {
             request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
         }
 

--- a/index.js
+++ b/index.js
@@ -46,16 +46,6 @@ const _extractVersionFromAcceptHeader = function (request, options) {
     return null;
 };
 
-//Checks if server.match returns expected versioned route
-const _isRouteVersioned = function (route, versionedPath) {
-
-    const routePath = route ? route.path : '';
-    const routePathItems = routePath.split('/'); //Split to account for path parameters
-    const versionedPathItems = versionedPath.split('/'); //Split to account for path parameters
-
-    return routePathItems.length === versionedPathItems.length;
-};
-
 exports.register = function (server, options, next) {
 
     const validateOptions = internals.optionsSchema.validate(options);
@@ -87,15 +77,18 @@ exports.register = function (server, options, next) {
             requestedVersion = options.defaultVersion;
         }
 
-
         const versionedPath = '/v' + requestedVersion + request.path;
 
         const route = server.match(request.method, versionedPath);
 
-        const validMatch = _isRouteVersioned(route, versionedPath);
+        if (!!route && route.hasOwnProperty('path')) {
 
-        if (validMatch) {
-            request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
+            //Check if returned route's path contains version
+            const versionedRoute = route.path.indexOf('/v' + requestedVersion + '/') === 0;
+
+            if (versionedRoute) {
+                request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
+            }
         }
 
         //Set version for usage in handler

--- a/index.js
+++ b/index.js
@@ -81,14 +81,15 @@ exports.register = function (server, options, next) {
 
         const route = server.match(request.method, versionedPath);
 
+        let versionedRoute = false;
+
+        //Check if returned route's path contains version
         if (!!route && route.hasOwnProperty('path')) {
+            versionedRoute = route.path.indexOf('/v' + requestedVersion + '/') === 0;
+        }
 
-            //Check if returned route's path contains version
-            const versionedRoute = route.path.indexOf('/v' + requestedVersion + '/') === 0;
-
-            if (versionedRoute) {
-                request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
-            }
+        if (versionedRoute) {
+            request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
         }
 
         //Set version for usage in handler

--- a/index.js
+++ b/index.js
@@ -49,11 +49,11 @@ const _extractVersionFromAcceptHeader = function (request, options) {
 //Checks if server.match returns expected versioned route
 const _isRouteVersioned = function (route, versionedPath) {
 
-    const fingerprint = route ? route.fingerprint : '';
-    const fingerprintItems = fingerprint.split('/'); //Split to account for path parameters
+    const routePath = route ? route.path : '';
+    const routePathItems = routePath.split('/'); //Split to account for path parameters
     const versionedPathItems = versionedPath.split('/'); //Split to account for path parameters
 
-    return fingerprintItems.length === versionedPathItems.length;
+    return routePathItems.length === versionedPathItems.length;
 };
 
 exports.register = function (server, options, next) {

--- a/test/index.js
+++ b/test/index.js
@@ -329,10 +329,43 @@ describe('Versioning', () => {
 
         server.route({
             method: 'GET',
-            path: '/{unversionedPathParam}',
+            path: '/unversioned/{catchAll*}',
             handler: function (request, reply) {
 
-                return reply(request.params.unversionedPathParam);
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: 'unversionedCatchAll'
+                };
+
+                return reply(response);
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/versioned/{catchAll*}',
+            handler: function (request, reply) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: 'versionedCatchAll'
+                };
+
+                return reply(response);
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/unversioned/{unversionedPathParam}',
+            handler: function (request, reply) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.unversionedPathParam
+                };
+
+                return reply(response);
             }
         });
 
@@ -341,7 +374,40 @@ describe('Versioning', () => {
             path: '/v1/versioned/{versionedPathParam}/withPathParams',
             handler: function (request, reply) {
 
-                return reply(request.params.versionedPathParam);
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.versionedPathParam
+                };
+
+                return reply(response);
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/versioned/{segment*2}/withPathParams',
+            handler: function (request, reply) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.segment
+                };
+
+                return reply(response);
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/versioned/optionalPathParam/{optional?}',
+            handler: function (request, reply) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.optional
+                };
+
+                return reply(response);
             }
         });
 
@@ -563,17 +629,55 @@ describe('Versioning', () => {
         });
     });
 
+    it('resolves unversioned catch all routes', (done) => {
+
+        server.inject({
+            method: 'GET',
+            url: '/unversioned/catch/all/route'
+        }, (response) => {
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('unversionedCatchAll');
+
+            done();
+
+        });
+    });
+
+    it('resolves versioned catch all routes', (done) => {
+
+        const apiVersion = 2;
+
+        server.inject({
+            method: 'GET',
+            url: '/versioned/catch/all/route',
+            headers: {
+                'api-version': apiVersion
+            }
+        }, (response) => {
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(apiVersion);
+            expect(response.result.data).to.equal('versionedCatchAll');
+
+            done();
+
+        });
+    });
+
     it('resolves unversioned routes with path parameters', (done) => {
 
         const pathParam = '123456789';
 
         server.inject({
             method: 'GET',
-            url: '/' + pathParam
+            url: '/unversioned/' + pathParam
         }, (response) => {
 
             expect(response.statusCode).to.equal(200);
-            expect(response.payload).to.equal(pathParam);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal(pathParam);
 
             done();
         });
@@ -582,20 +686,65 @@ describe('Versioning', () => {
     it('resolves versioned routes with path parameters', (done) => {
 
         const pathParam = '123456789';
+        const apiVersion = 1;
 
         server.inject({
             method: 'GET',
             url: '/versioned/' + pathParam + '/withPathParams',
             headers: {
-                'api-version': '1'
+                'api-version': apiVersion
             }
         }, (response) => {
 
             expect(response.statusCode).to.equal(200);
-            expect(response.payload).to.equal(pathParam);
+            expect(response.result.version).to.equal(apiVersion);
+            expect(response.result.data).to.equal(pathParam);
 
             done();
         });
     });
+
+    it('resolves multi segment path parameters', (done) => {
+
+        const apiVersion = 2;
+        const pathParam = 'multi/segment';
+
+        server.inject({
+            method: 'GET',
+            url: '/versioned/' + pathParam + '/withPathParams',
+            headers: {
+                'api-version': apiVersion
+            }
+        }, (response) => {
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(apiVersion);
+            expect(response.result.data).to.equal(pathParam);
+
+            done();
+        });
+    });
+
+    it('resolves optional path parameters', (done) => {
+
+        const apiVersion = 2;
+        const pathParam = undefined;
+
+        server.inject({
+            method: 'GET',
+            url: '/versioned/optionalPathParam/',
+            headers: {
+                'api-version': apiVersion
+            }
+        }, (response) => {
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(apiVersion);
+            expect(response.result.data).to.equal(pathParam);
+
+            done();
+        });
+    });
+
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -327,6 +327,24 @@ describe('Versioning', () => {
             }
         });
 
+        server.route({
+            method: 'GET',
+            path: '/{unversionedPathParam}',
+            handler: function (request, reply) {
+
+                return reply(request.params.unversionedPathParam);
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v1/versioned/{versionedPathParam}/withPathParams',
+            handler: function (request, reply) {
+
+                return reply(request.params.versionedPathParam);
+            }
+        });
+
         done();
     });
 
@@ -540,6 +558,41 @@ describe('Versioning', () => {
 
             expect(response.headers).to.include('access-control-allow-headers');
             expect(response.headers['access-control-allow-headers'].split(',')).to.include(['Accept', 'Authorization']);
+
+            done();
+        });
+    });
+
+    it('resolves unversioned routes with path parameters', (done) => {
+
+        const pathParam = '123456789';
+
+        server.inject({
+            method: 'GET',
+            url: '/' + pathParam
+        }, (response) => {
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.payload).to.equal(pathParam);
+
+            done();
+        });
+    });
+
+    it('resolves versioned routes with path parameters', (done) => {
+
+        const pathParam = '123456789';
+
+        server.inject({
+            method: 'GET',
+            url: '/versioned/' + pathParam + '/withPathParams',
+            headers: {
+                'api-version': '1'
+            }
+        }, (response) => {
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.payload).to.equal(pathParam);
 
             done();
         });


### PR DESCRIPTION
[5fa65c3](https://github.com/p-meier/hapi-api-version/commit/5fa65c36e9ee468566c1e27717ef7a71e35b107e) fails to account for path parameters and thus introduces a breaking change: 

ex)
route.path: `/v2/user/{id}`
versionedPath: `/v2/user/123`

```javascript
if (route && route.path === versionedPath) {
    request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
}
```

As `'/v2/user/{id}'` is obviously not equal to `'/v2/user/123'`, the expected versioned url will never be set. This is unfortunate, path parameters are great! This fix checks the `route.fingerprint` against the `versionedPath` to  add support for path parameters while maintaining support for unversioned, versioned, and wildcard paths.
