### PR TITLE
Adding ability to parse Accept headers of different formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,24 @@ const MediaType = require('media-type');
 
 const Package = require('./package');
 
+const _acceptHeader = {
+    subtypeTest: /^vnd.[a-zA-Z0-9]+\.v[0-9]+$/,
+    extractVersion: function (media) {
+
+        return  media.subtypeFacets[2].replace('v', '');
+    }
+};
+
 const internals = {
     optionsSchema: Joi.object({
         validVersions: Joi.array().items(Joi.number().integer()).min(1).required(),
         defaultVersion: Joi.any().valid(Joi.ref('validVersions')).required(),
         vendorName: Joi.string().trim().min(1).required(),
-        versionHeader: Joi.string().trim().min(1).default('api-version')
+        versionHeader: Joi.string().trim().min(1).default('api-version'),
+        acceptHeader: Joi.object({
+            subtypeTest: Joi.object().type(RegExp).default(_acceptHeader.subtypeTest),
+            extractVersion: Joi.func().arity(1).default(_acceptHeader.extractVersion)
+        }).default(_acceptHeader)
     })
 };
 
@@ -32,13 +44,13 @@ const _extractVersionFromAcceptHeader = function (request, options) {
     const acceptHeader = request.headers.accept;
     const media = MediaType.fromString(acceptHeader);
 
-    if (media.isValid() && (/^vnd.[a-zA-Z0-9]+\.v[0-9]+$/).test(media.subtype)) {
+    if (media.isValid() && (options.acceptHeader.subtypeTest).test(media.subtype)) {
 
         if (media.subtypeFacets[1] !== options.vendorName) {
             return null;
         }
 
-        const version = media.subtypeFacets[2].replace('v', '');
+        const version = options.acceptHeader.extractVersion(media);
 
         return parseInt(version);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -203,6 +203,69 @@ describe('Plugin registration', () => {
         });
     });
 
+    it('should fail if acceptHeader.subtypeTest is not a RegExp', (done) => {
+
+        server.register({
+            register: require('../'),
+            options: {
+                validVersions: [1, 2],
+                defaultVersion: 1,
+                vendorName: 'mysuperapi',
+                acceptHeader: {
+                    subtypeTest: 'abc'
+                }
+            }
+        }, (err) => {
+
+            if (err) {
+                done();
+            }
+        });
+    });
+
+    it('should fail if acceptHeader.extractVersion is not a function', (done) => {
+
+        server.register({
+            register: require('../'),
+            options: {
+                validVersions: [1, 2],
+                defaultVersion: 1,
+                vendorName: 'mysuperapi',
+                acceptHeader: {
+                    extractVersion: 'abc'
+                }
+            }
+        }, (err) => {
+
+            if (err) {
+                done();
+            }
+        });
+    });
+
+    it('should fail if acceptHeader.extractVersion is not a function with arity of 1', (done) => {
+
+        server.register({
+            register: require('../'),
+            options: {
+                validVersions: [1, 2],
+                defaultVersion: 1,
+                vendorName: 'mysuperapi',
+                acceptHeader: {
+                    extractVersion: function () {
+
+                        return 1;
+                    }
+                }
+            }
+        }, (err) => {
+
+            if (err) {
+                done();
+            }
+        });
+    });
+
     it('should succeed if all required options are provided correctly', (done) => {
 
         server.register({
@@ -228,7 +291,14 @@ describe('Plugin registration', () => {
                 validVersions: [1, 2],
                 defaultVersion: 1,
                 vendorName: 'mysuperapi',
-                versionHeader: 'myversion'
+                versionHeader: 'myversion',
+                acceptHeader: {
+                    subtypeTest: /vnd.mysuperapi/,
+                    extractVersion: function (media) {
+
+                        return 3;
+                    }
+                }
             }
         }, (err) => {
 
@@ -476,6 +546,153 @@ describe('Versioning', () => {
                 expect(response.statusCode).to.equal(200);
                 expect(response.result.version).to.equal(1);
                 expect(response.result.data).to.equal('unversioned');
+
+                done();
+            });
+        });
+    });
+
+    describe(' -> accept header versioning with option overrides', () => {
+
+        let server2;
+
+        beforeEach((done) => {
+
+            server2 = new Hapi.Server();
+            server2.connection();
+
+            server2.register([{
+                register: require('../'),
+                options: {
+                    validVersions: [1, 2],
+                    defaultVersion: 1,
+                    vendorName: 'mysuperapi',
+                    acceptHeader: {
+                        subtypeTest: /^vnd.[a-zA-Z0-9]+$/,
+                        extractVersion: function (media) {
+
+                            return media.parameters.version;
+                        }
+                    }
+                }
+            }], (err) => {
+
+                if (err) {
+                    return console.error('Can not register plugins', err);
+                }
+            });
+
+            server2.route({
+                method: 'GET',
+                path: '/v1/versioned',
+                handler: function (request, reply) {
+
+                    const response = {
+                        version: 1,
+                        data: 'versioned'
+                    };
+
+                    return reply(response);
+                }
+            });
+
+            server2.route({
+                method: 'GET',
+                path: '/v2/versioned',
+                handler: function (request, reply) {
+
+                    const response = {
+                        version: 2,
+                        data: 'versioned'
+                    };
+
+                    return reply(response);
+                }
+            });
+
+            done();
+        });
+
+        it('returns version 2 if accept header is valid', (done) => {
+
+            server2.inject({
+                method: 'GET',
+                url: '/versioned',
+                headers: {
+                    'Accept': 'application/vnd.mysuperapi+json; version=2'
+                }
+            }, (response) => {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.version).to.equal(2);
+                expect(response.result.data).to.equal('versioned');
+
+                done();
+            });
+        });
+
+        it('returns default version if no header is sent', (done) => {
+
+            server2.inject({
+                method: 'GET',
+                url: '/versioned'
+            }, (response) => {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.version).to.equal(1);
+                expect(response.result.data).to.equal('versioned');
+
+                done();
+            });
+        });
+
+        it('returns default version if accept header is invalid', (done) => {
+
+            server2.inject({
+                method: 'GET',
+                url: '/versioned',
+                headers: {
+                    'Accept': 'application/someinvalidapi+json'
+                }
+            }, (response) => {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.version).to.equal(1);
+                expect(response.result.data).to.equal('versioned');
+
+                done();
+            });
+        });
+
+        it('returns default version if accept header has an invalid vendor-name', (done) => {
+
+            server2.inject({
+                method: 'GET',
+                url: '/versioned',
+                headers: {
+                    'Accept': 'application/vnd.someinvalidapi+json; version=2'
+                }
+            }, (response) => {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.version).to.equal(1);
+                expect(response.result.data).to.equal('versioned');
+
+                done();
+            });
+        });
+
+        it('returns a 400 if invalid api version is requested (not included in validVersions)', (done) => {
+
+            server2.inject({
+                method: 'GET',
+                url: '/versioned',
+                headers: {
+                    'Accept': 'application/vnd.mysuperapi+json; version=3'
+                }
+            }, (response) => {
+
+                expect(response.statusCode).to.equal(400);
 
                 done();
             });


### PR DESCRIPTION
Adds ability to override the accept header subtype validity check by passing a regex in registration options.
Adds ability to override the functionality for version extraction from the header.

#### Motivation for the addition of these overrides:
We have multiple apps running on different frameworks and we are wanting to get the version string in the Accept header to be consistent across the apps.

For instance we have a hapi app that looks for an Accept header like the following: `application/vnd.myapi.v2+json`

And we have a rails app that is looking for an Accept header like the following: `application/vnd.myapi+json; version=2`

#### Example of options added that would allow an Accept head like the following
`application/vnd.myapi+json; version=2`
```
{
  acceptHeader: {
    subtypeTest: /^vnd.[a-zA-Z0-9]+$/,
    extractVersion: function (media) {
      return media.parameters.version;
    }
  }
}
```