### PR TITLE
Add passiveMode option to prevent breaking non-versioned routes/resources and reduce overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The options for the plugin are validated on plugin registration.
 - `vendorName` (required) is a string. Defines the vendor name used in the `accept` header.
 - `versionHeader` (optional) is a string. Defines the name of the custom header to use. Per default this is `api-version`.
 - `passiveMode` (optional) is a boolean. Allows to bypass when no headers are supplied. Useful when you have serve other content like documentation and reduces overhead on processing those.
+- `basePath` (optional) is a string. In case we have a base path different from `/` (example: `/api/`). Per default this is `/`.
 
 ### Getting the requested API version in the handler
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The options for the plugin are validated on plugin registration.
 - `defaultVersion` (required) is an integer that is included in `validVersions`. Defines which version to use if no headers are sent.
 - `vendorName` (required) is a string. Defines the vendor name used in the `accept` header.
 - `versionHeader` (optional) is a string. Defines the name of the custom header to use. Per default this is `api-version`.
+- `passiveMode` (optional) is a boolean. Allows to bypass when no headers are supplied. Useful when you have serve other content like documentation and reduces overhead on processing those.
 
 ### Getting the requested API version in the handler
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ const internals = {
         defaultVersion: Joi.any().valid(Joi.ref('validVersions')).required(),
         vendorName: Joi.string().trim().min(1).required(),
         versionHeader: Joi.string().trim().min(1).default('api-version'),
-        passiveMode: Joi.boolean().default(false)
+        passiveMode: Joi.boolean().default(false),
+        basePath: Joi.string().trim().min(1).default('/')
     })
 };
 
@@ -83,12 +84,12 @@ exports.register = function (server, options, next) {
             requestedVersion = options.defaultVersion;
         }
 
-        const versionedPath = '/v' + requestedVersion + request.path;
+        const versionedPath = options.basePath + 'v' + requestedVersion + request.path.slice(options.basePath.length - 1);
 
         const route = server.match(request.method, versionedPath);
 
-        if (route && route.path.indexOf('/v' + requestedVersion + '/') === 0) {
-            request.setUrl('/v' + requestedVersion + request.url.path); //required to preserve query parameters
+        if (route && route.path.indexOf(options.basePath + 'v' + requestedVersion + '/') === 0) {
+            request.setUrl(options.basePath + 'v' + requestedVersion + request.url.path.slice(options.basePath.length - 1)); //required to preserve query parameters
         }
 
         //Set version for usage in handler

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ const internals = {
         validVersions: Joi.array().items(Joi.number().integer()).min(1).required(),
         defaultVersion: Joi.any().valid(Joi.ref('validVersions')).required(),
         vendorName: Joi.string().trim().min(1).required(),
-        versionHeader: Joi.string().trim().min(1).default('api-version')
+        versionHeader: Joi.string().trim().min(1).default('api-version'),
+        passiveMode: Joi.boolean().default(false)
     })
 };
 
@@ -65,6 +66,11 @@ exports.register = function (server, options, next) {
         //If no version check accept header
         if (!requestedVersion) {
             requestedVersion = _extractVersionFromAcceptHeader(request, options);
+        }
+
+        //If passive mode skips the rest for non versioned routes
+        if (options.passiveMode === true && !requestedVersion) {
+            return reply.continue();
         }
 
         //If there was a version by now check if it is valid

--- a/test/index.js
+++ b/test/index.js
@@ -203,6 +203,24 @@ describe('Plugin registration', () => {
         });
     });
 
+    it('should fail if passiveMode is not a boolean', (done) => {
+
+        server.register({
+            register: require('../'),
+            options: {
+                validVersions: [1, 2],
+                defaultVersion: 1,
+                vendorName: 33,
+                passiveMode: []
+            }
+        }, (err) => {
+
+            if (err) {
+                done();
+            }
+        });
+    });
+
     it('should succeed if all required options are provided correctly', (done) => {
 
         server.register({
@@ -228,7 +246,8 @@ describe('Plugin registration', () => {
                 validVersions: [1, 2],
                 defaultVersion: 1,
                 vendorName: 'mysuperapi',
-                versionHeader: 'myversion'
+                versionHeader: 'myversion',
+                passiveMode: true
             }
         }, (err) => {
 
@@ -781,3 +800,55 @@ describe('Versioning', () => {
         });
     });
 });
+
+describe('Versioning with passive mode', () => {
+
+    beforeEach((done) => {
+
+        server.register([{
+            register: require('../'),
+            options: {
+                validVersions: [1, 2],
+                defaultVersion: 1,
+                vendorName: 'mysuperapi',
+                passiveMode: true
+            }
+        }], (err) => {
+
+            if (err) {
+                return console.error('Can not register plugins', err);
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/unversioned',
+            handler: function (request, reply) {
+
+                const response = {
+                    data: 'unversioned'
+                };
+
+                return reply(response);
+            }
+        });
+
+        done();
+    });
+
+    it('returns no version if no header is supplied', (done) => {
+
+        server.inject({
+            method: 'GET',
+            url: '/unversioned'
+        }, (response) => {
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(undefined);
+            expect(response.result.data).to.equal('unversioned');
+
+            done();
+        });
+    });
+});
+


### PR DESCRIPTION
### passiveMode

When having a server that runs the API side-by-side with the documentation (ex: happi-swagger) we don't want to append version to the request path because simply it's not intended.  `passiveMode` solves this preventing breaking non-versioned routes/resources and reduces overhead.

### basePath

Allows to use the plugin when having a base path different from `/`.