### PR TITLE
add a response header containing the API version

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,21 @@ const _extractVersionFromAcceptHeader = function (request, options) {
     return null;
 };
 
+//Set a response header containing the version number
+const _addVersionToResponseHeader = function (request, reply, requestedVersion, options) {
+
+    const headerName = options.versionHeader;
+    const response = request.response;
+
+    if (request.response.isBoom) {
+        response.output.headers[headerName] = requestedVersion;
+    }
+    else {
+        response.header(headerName, requestedVersion);
+    }
+    reply.continue();
+};
+
 exports.register = function (server, options, next) {
 
     const validateOptions = internals.optionsSchema.validate(options);
@@ -96,6 +111,11 @@ exports.register = function (server, options, next) {
         request.pre.apiVersion = requestedVersion;
 
         return reply.continue();
+    });
+
+    server.ext('onPreResponse', (request, reply) => {
+
+        _addVersionToResponseHeader(request, reply, request.pre.apiVersion, options);
     });
 
     return next();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-api-version",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "An API versioning plugin for hapi.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -379,6 +379,41 @@ describe('Versioning', () => {
             });
         });
 
+        it('returns default version response header if no request header is sent', (done) => {
+
+            server.inject({
+                method: 'GET',
+                url: '/versioned'
+            }, (response) => {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.version).to.equal(1);
+                expect(response.result.data).to.equal('versioned');
+                expect(response.headers['api-version']).to.equal(1);
+
+                done();
+            });
+        });
+
+        it('returns version response header if response header is present', (done) => {
+
+            server.inject({
+                method: 'GET',
+                url: '/versioned',
+                headers: {
+                    'api-version': '2'
+                }
+            }, (response) => {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.version).to.equal(2);
+                expect(response.result.data).to.equal('versioned');
+                expect(response.headers['api-version']).to.equal(2);
+
+                done();
+            });
+        });
+
         it('returns default version if custom header is invalid', (done) => {
 
             server.inject({


### PR DESCRIPTION
Previously, there was no way to know what version of the API you were getting back.  Now, you can get a response header back with the version number in it.

I find this very helpful.  I am using your plugin right now, and love it.

Without this, you would have include the version # directly into the response JSON.  That's fine, probably should be done that way, but this is another great way to check the version #.