### PR TITLE
Hapi v17 Compatibility Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,10 @@
 language: node_js
 
 node_js:
-    - 4.0
-    - 4
-    - 5
-    - 6
-    - 7
     - 8
 
 env:
-    - HAPI_VERSION="10"
-    - HAPI_VERSION="11"
-    - HAPI_VERSION="12"
-    - HAPI_VERSION="13"
-    - HAPI_VERSION="14"
-    - HAPI_VERSION="15"
-    - HAPI_VERSION="16"
+    - HAPI_VERSION="17"
 
 install:
     - npm install --no-package-lock

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ __Lead Maintainer: [Tim Costa](https://github.com/timcosta)__
 
 [![Build Status](https://travis-ci.org/p-meier/hapi-api-version.svg?branch=master)](https://travis-ci.org/p-meier/hapi-api-version)
 
-An API versioning plugin for [hapi](http://hapijs.com/).
+An API versioning plugin for [hapi](http://hapijs.com/) v17 onwards.
 
 ## Features / Goals
 
@@ -16,7 +16,7 @@ An API versioning plugin for [hapi](http://hapijs.com/).
 
 ## Requirements
 
-Runs with Node >=4 and hapi >=10 which is tested with Travis CI.
+Runs with Node >=8 and hapi >=17 which is tested with Travis CI.
 
 ## Installation
 
@@ -33,26 +33,26 @@ Register it with the server:
 
 const Hapi = require('hapi');
 
-const server = new Hapi.Server();
-server.connection({
-    port: 3000
-});
-
-server.register({
-    register: require('hapi-api-version'),
-    options: {
-        validVersions: [1, 2],
-        defaultVersion: 2,
-        vendorName: 'mysuperapi'
-    }
-}, (err) => {
-
-    //Add routes here...
-
-    server.start((err) => {
+const init = async function () {
+    try {
+        const server = new Hapi.server({ port: 3000 });
+        await server.register({
+            register: require('hapi-api-version'),
+            options: {
+                validVersions: [1, 2],
+                defaultVersion: 2,
+                vendorName: 'mysuperapi'
+            }
+        })
+        await server.start();
         console.log('Server running at:', server.info.uri);
-    });
-});
+    }   
+    catch (err) {
+        console.error(err);
+        process.exit(1);
+    }
+}
+init();
 
 ```
 
@@ -68,13 +68,13 @@ This is the type of routes which never change regardless of the api version. The
 server.route({
     method: 'GET',
     path:'/loginStatus',
-    handler: function (request, reply) {
+    handler: function (request, h) {
 
         const loggedIn = ...;
 
-        return reply({
+        return {
           loggedIn: loggedIn
-        });
+        );
     }
 });
 ```
@@ -100,15 +100,15 @@ const usersVersion2 = [{
 server.route({
     method: 'GET',
     path: '/users',
-    handler: function (request, reply) {
+    handler: function (request, h) {
 
         const version = request.pre.apiVersion;
 
         if (version === 1) {
-            return reply(usersVersion1);
+            return usersVersion1;
         }
 
-        return reply(usersVersion2);
+        return usersVersion2;
     }
 });
 ```
@@ -130,9 +130,9 @@ const usersVersion2 = [{
 server.route({
     method: 'GET',
     path: '/v1/users',
-    handler: function (request, reply) {
+    handler: function (request, h) {
 
-        return reply(usersVersion1);
+        return usersVersion1;
     },
     config: {
         response: {
@@ -148,9 +148,9 @@ server.route({
 server.route({
     method: 'GET',
     path: '/v2/users',
-    handler: function (request, reply) {
+    handler: function (request, h) {
 
-        return reply(usersVersion2);
+        return usersVersion2;
     },
     config: {
         response: {

--- a/example/index.js
+++ b/example/index.js
@@ -3,115 +3,106 @@
 const Hapi = require('hapi');
 const Joi = require('joi');
 
-// Create a server with a host and port
-const server = new Hapi.Server();
-server.connection({
-    port: 3000
-});
+const init = async function () {
 
-// Start the server
-server.register({
-    register: require('../'),
-    options: {
-        validVersions: [1, 2],
-        defaultVersion: 2,
-        vendorName: 'mysuperapi'
-    }
-}, (err) => {
-
-    if (err) {
-        throw err;
-    }
-
-    // Add a route - handler and route definition is the same for all versions
-    server.route({
-        method: 'GET',
-        path: '/version',
-        handler: function (request, reply) {
-
-            // Return the api-version which was requested
-            return reply({
-                version: request.pre.apiVersion
-            });
-        }
-    });
-
-    const usersVersion1 = [{
-        name: 'Peter Miller'
-    }];
-
-    const usersVersion2 = [{
-        firtname: 'Peter',
-        lastname: 'Miller'
-    }];
-
-    // Add a versioned route - which is actually two routes with prefix '/v1' and '/v2'. Not only the
-    // handlers are different, but also the route defintion itself (like here with response validation).
-    server.route({
-        method: 'GET',
-        path: '/v1/users',
-        handler: function (request, reply) {
-
-            return reply(usersVersion1);
-        },
-        config: {
-            response: {
-                schema: Joi.array().items(
-                    Joi.object({
-                        name: Joi.string().required()
-                    })
-                )
+    try {
+        const server = new Hapi.server({ port: 3000 });
+        await server.register({
+            register: require('hapi-api-version'),
+            options: {
+                validVersions: [1, 2],
+                defaultVersion: 2,
+                vendorName: 'mysuperapi'
             }
-        }
-    });
+        });
+        // Add a route - handler and route definition is the same for all versions
+        server.route({
+            method: 'GET',
+            path: '/version',
+            handler: function (request, reply) {
 
-    server.route({
-        method: 'GET',
-        path: '/v2/users',
-        handler: function (request, reply) {
-
-            return reply(usersVersion2);
-        },
-        config: {
-            response: {
-                schema: Joi.array().items(
-                    Joi.object({
-                        firtname: Joi.string().required(),
-                        lastname: Joi.string().required()
-                    })
-                )
+                // Return the api-version which was requested
+                return reply({
+                    version: request.pre.apiVersion
+                });
             }
-        }
+        });
 
-    });
+        const usersVersion1 = [{
+            name: 'Peter Miller'
+        }];
 
-    // Add a versioned route - This is a simple version of the '/users' route where just the handlers
-    // differ and even those just a little. It maybe is the preferred option if just the formatting of
-    // the response differs between versions.
+        const usersVersion2 = [{
+            firtname: 'Peter',
+            lastname: 'Miller'
+        }];
 
-    server.route({
-        method: 'GET',
-        path: '/users/simple',
-        handler: function (request, reply) {
+        // Add a versioned route - which is actually two routes with prefix '/v1' and '/v2'. Not only the
+        // handlers are different, but also the route defintion itself (like here with response validation).
+        server.route({
+            method: 'GET',
+            path: '/v1/users',
+            handler: function (request, reply) {
 
-            const version = request.pre.apiVersion;
-
-            if (version === 1) {
                 return reply(usersVersion1);
+            },
+            config: {
+                response: {
+                    schema: Joi.array().items(
+                        Joi.object({
+                            name: Joi.string().required()
+                        })
+                    )
+                }
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/users',
+            handler: function (request, reply) {
+
+                return reply(usersVersion2);
+            },
+            config: {
+                response: {
+                    schema: Joi.array().items(
+                        Joi.object({
+                            firtname: Joi.string().required(),
+                            lastname: Joi.string().required()
+                        })
+                    )
+                }
             }
 
-            return reply(usersVersion2);
-        }
-    });
+        });
 
-    // Start the server
-    server.start((err) => {
+        // Add a versioned route - This is a simple version of the '/users' route where just the handlers
+        // differ and even those just a little. It maybe is the preferred option if just the formatting of
+        // the response differs between versions.
 
-        if (err) {
-            throw err;
-        }
+        server.route({
+            method: 'GET',
+            path: '/users/simple',
+            handler: function (request, reply) {
 
+                const version = request.pre.apiVersion;
+
+                if (version === 1) {
+                    return reply(usersVersion1);
+                }
+
+                return reply(usersVersion2);
+            }
+        });
+        // Start the server
+        await server.start();
         console.log('Server running at:', server.info.uri);
-    });
+    }
+    catch (err) {
+        console.error(err);
+        process.exit(1);
+    };
+};
+init();
 
-});

--- a/example/index.js
+++ b/example/index.js
@@ -8,7 +8,7 @@ const init = async function () {
     try {
         const server = new Hapi.server({ port: 3000 });
         await server.register({
-            register: require('hapi-api-version'),
+            plugin: require('hapi-api-version'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: 2,
@@ -19,12 +19,12 @@ const init = async function () {
         server.route({
             method: 'GET',
             path: '/version',
-            handler: function (request, reply) {
+            handler: function (request, h) {
 
                 // Return the api-version which was requested
-                return reply({
+                return {
                     version: request.pre.apiVersion
-                });
+                };
             }
         });
 
@@ -42,9 +42,9 @@ const init = async function () {
         server.route({
             method: 'GET',
             path: '/v1/users',
-            handler: function (request, reply) {
+            handler: function (request, h) {
 
-                return reply(usersVersion1);
+                return usersVersion1;
             },
             config: {
                 response: {
@@ -60,9 +60,9 @@ const init = async function () {
         server.route({
             method: 'GET',
             path: '/v2/users',
-            handler: function (request, reply) {
+            handler: function (request, h) {
 
-                return reply(usersVersion2);
+                return usersVersion2;
             },
             config: {
                 response: {
@@ -84,15 +84,15 @@ const init = async function () {
         server.route({
             method: 'GET',
             path: '/users/simple',
-            handler: function (request, reply) {
+            handler: function (request, h) {
 
                 const version = request.pre.apiVersion;
 
                 if (version === 1) {
-                    return reply(usersVersion1);
+                    return usersVersion1;
                 }
 
-                return reply(usersVersion2);
+                return usersVersion2;
             }
         });
         // Start the server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-api-version",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "An API versioning plugin for hapi.",
   "main": "index.js",
   "scripts": {
@@ -20,15 +20,15 @@
   "author": "Patrick Meier",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "peerDependencies": {
-    "hapi": ">=10.x.x"
+    "hapi": ">=17.x.x"
   },
   "devDependencies": {
-    "code": "^4.1.0",
-    "hapi": "^16.5.2",
-    "lab": "^14.2.0"
+    "hapi": "17.x.x",
+    "code": "5.x.x",
+    "lab": "15.x.x"
   },
   "dependencies": {
     "boom": "^5.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 const Hapi = require('hapi');
 const Code = require('code');
 const Lab = require('lab');
+
 const lab = exports.lab = Lab.script();
 
 const expect = Code.expect;
@@ -10,202 +11,166 @@ const expect = Code.expect;
 const describe = lab.describe;
 const it = lab.it;
 const beforeEach = lab.beforeEach;
-
 let server;
 
-beforeEach((done) => {
+beforeEach(async () => {
 
-    server = new Hapi.Server();
-    server.connection();
-
-    done();
+    try {
+        server = Hapi.server();
+        await server.start();
+    }
+    catch (err) {
+        console.error(err);
+        process.exit(1);
+    }
 });
 
 describe('Plugin registration', () => {
 
-    it('should fail if no options are specified', (done) => {
+    it('should throw error if no options are specified', (done) => {
 
-        server.register({
-            register: require('../'),
-            options: {}
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        try {
+            server.register({
+                plugin: require('../'),
+                options: {}
+            }).then(() => {
+            }).catch((e) => expect(e).to.be.an.instanceof(Error));
+        }
+        catch (e) {
+            done();
+        };
     });
 
-    it('should fail if no validVersions are specified', (done) => {
 
-        server.register({
+    it('should fail if no options are specified', async () => {
+
+        await expect(server.register({
+            register: require('../'),
+            options: {}
+        })).to.reject(Error, /Invalid plugin options/);
+    });
+
+    it('should fail if no validVersions are specified', async () => {
+
+        await expect(server.register({
             register: require('../'),
             options: {
                 defaultVersion: 1,
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if validVersions is not an array', (done) => {
+    it('should fail if validVersions is not an array', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: 1,
                 defaultVersion: 1,
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
+        })).to.reject(Error, /Invalid plugin options/);
 
-            if (err) {
-                done();
-            }
-        });
     });
 
-    it('should fail if validVersions is an empty array', (done) => {
+    it('should fail if validVersions is an empty array', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [],
                 defaultVersion: 1,
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if validVersions contains non integer values', (done) => {
+    it('should fail if validVersions contains non integer values', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: ['1', 2.2],
                 defaultVersion: 1,
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if no defaultVersion is specified', (done) => {
+    it('should fail if no defaultVersion is specified', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if defaultVersion is not an integer', (done) => {
+    it('should fail if defaultVersion is not an integer', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: '1',
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if defaultVersion is not an element of validVersions', (done) => {
+    it('should fail if defaultVersion is not an element of validVersions', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: 3,
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if defaultVersion is not an element of validVersions', (done) => {
+    it('should fail if defaultVersion is not an element of validVersions', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: 3,
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if no vendorName is specified', (done) => {
+    it('should fail if no vendorName is specified', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: 1
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if vendorName is not a string', (done) => {
+    it('should fail if vendorName is not a string', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: 1,
                 vendorName: 33
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should fail if passiveMode is not a boolean', (done) => {
+    it('should fail if passiveMode is not a boolean', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
@@ -213,34 +178,24 @@ describe('Plugin registration', () => {
                 vendorName: 33,
                 passiveMode: []
             }
-        }, (err) => {
-
-            if (err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should succeed if all required options are provided correctly', (done) => {
+    it('should succeed if all required options are provided correctly', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: 1,
                 vendorName: 'mysuperapi'
             }
-        }, (err) => {
-
-            if (!err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 
-    it('should succeed if all options are provided correctly', (done) => {
+    it('should succeed if all options are provided correctly', async () => {
 
-        server.register({
+        await expect(server.register({
             register: require('../'),
             options: {
                 validVersions: [1, 2],
@@ -249,380 +204,306 @@ describe('Plugin registration', () => {
                 versionHeader: 'myversion',
                 passiveMode: true
             }
-        }, (err) => {
-
-            if (!err) {
-                done();
-            }
-        });
+        })).to.reject(Error, /Invalid plugin options/);
     });
 });
 
 describe('Versioning', () => {
 
-    beforeEach((done) => {
+    beforeEach(async () => {
 
-        server.register([{
-            register: require('../'),
+        await server.register({
+            plugin: require('../'),
             options: {
                 validVersions: [0, 1, 2],
                 defaultVersion: 1,
                 vendorName: 'mysuperapi'
             }
-        }], (err) => {
-
-            if (err) {
-                return console.error('Can not register plugins', err);
-            }
         });
-
-        done();
     });
 
     describe(' -> basic versioning', () => {
 
-        beforeEach((done) => {
+        beforeEach(() => {
 
             server.route({
                 method: 'GET',
                 path: '/unversioned',
-                handler: function (request, reply) {
+                handler: function (request, h) {
 
                     const response = {
                         version: request.pre.apiVersion,
                         data: 'unversioned'
                     };
 
-                    return reply(response);
+                    return response;
                 }
             });
 
             server.route({
                 method: 'GET',
                 path: '/v0/versioned',
-                handler: function (request, reply) {
+                handler: function (request, h) {
 
                     const response = {
                         version: 0,
                         data: 'versioned'
                     };
 
-                    return reply(response);
+                    return response;
                 }
             });
 
             server.route({
                 method: 'GET',
                 path: '/v1/versioned',
-                handler: function (request, reply) {
+                handler: function (request, h) {
 
                     const response = {
                         version: 1,
                         data: 'versioned'
                     };
 
-                    return reply(response);
+                    return response;
                 }
             });
 
             server.route({
                 method: 'GET',
                 path: '/v2/versioned',
-                handler: function (request, reply) {
+                handler: function (request, h) {
 
                     const response = {
                         version: 2,
                         data: 'versioned'
                     };
 
-                    return reply(response);
+                    return response;
                 }
             });
-
-            done();
         });
 
-        it('returns version 2 if custom header is valid', (done) => {
+        it('returns version 2 if custom header is valid', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'api-version': '2'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(2);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(2);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns version 0 if custom header is valid', (done) => {
+        it('returns version 0 if custom header is valid', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'api-version': '0'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(0);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(0);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns version 2 if accept header is valid', (done) => {
+        it('returns version 2 if accept header is valid', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'Accept': 'application/vnd.mysuperapi.v2+json'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(2);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(2);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns default version if no header is sent', (done) => {
+        it('returns default version if no header is sent', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned'
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns default version response header if no request header is sent', (done) => {
+        it('returns default version response header if no request header is sent', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned'
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('versioned');
-                expect(response.headers['api-version']).to.equal(1);
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('versioned');
+            expect(response.headers['api-version']).to.equal(1);
         });
 
-        it('returns version response header if response header is present', (done) => {
+        it('returns version response header if response header is present', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'api-version': '2'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(2);
-                expect(response.result.data).to.equal('versioned');
-                expect(response.headers['api-version']).to.equal(2);
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(2);
+            expect(response.result.data).to.equal('versioned');
+            expect(response.headers['api-version']).to.equal(2);
         });
 
-        it('returns default version if custom header is invalid', (done) => {
+        it('returns default version if custom header is invalid', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'api-version': 'asdf'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns default version if custom header is null', (done) => {
+        it('returns default version if custom header is null', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'api-version': null
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns default version if accept header is invalid', (done) => {
+        it('returns default version if accept header is invalid', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'Accept': 'application/someinvalidapi.vasf+json'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns default version if accept header has an invalid vendor-name', (done) => {
+        it('returns default version if accept header has an invalid vendor-name', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'Accept': 'application/vnd.someinvalidapi.v2+json'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('versioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('versioned');
         });
 
-        it('returns a 400 if invalid api version is requested (not included in validVersions)', (done) => {
+        it('returns a 400 if invalid api version is requested (not included in validVersions)', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/versioned',
                 headers: {
                     'api-version': '3'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(400);
-
-                done();
             });
+            expect(response.statusCode).to.equal(400);
         });
 
-        it('returns the same response for an unversioned route no matter what version is requested - version 1', (done) => {
+        it('returns the same response for an unversioned route no matter what version is requested - version 1', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/unversioned',
                 headers: {
                     'api-version': '1'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('unversioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('unversioned');
         });
 
-        it('returns the same response for an unversioned route no matter what version is requested - version 2', (done) => {
+        it('returns the same response for an unversioned route no matter what version is requested - version 2', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/unversioned',
                 headers: {
                     'api-version': '2'
                 }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(2);
-                expect(response.result.data).to.equal('unversioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(2);
+            expect(response.result.data).to.equal('unversioned');
         });
 
-        it('returns the same response for an unversioned route no matter what version is requested - no version (=default)', (done) => {
+        it('returns the same response for an unversioned route no matter what version is requested - no version (=default)', async () => {
 
-            server.inject({
+            const response = await server.inject({
                 method: 'GET',
                 url: '/unversioned'
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('unversioned');
-
-                done();
             });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(1);
+            expect(response.result.data).to.equal('unversioned');
         });
     });
 
-    it('preserves query parameters after url-rewrite', (done) => {
+    it('preserves query parameters after url-rewrite', async () => {
 
         server.route({
             method: 'GET',
             path: '/v1/versionedWithParams',
-            handler: function (request, reply) {
+            handler: function (request, h) {
 
                 const response = {
                     params: request.query
                 };
 
-                return reply(response);
+                return response;
             }
         });
 
-        server.inject({
+        const response = await server.inject({
             method: 'GET',
             url: '/versionedWithParams?test=1'
-        }, (response) => {
-
-            expect(response.statusCode).to.equal(200);
-            expect(response.result.params).to.equal({
-                test: '1'
-            });
-
-            done();
+        });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.params).to.equal({
+            test: '1'
         });
     });
 
-    it('should work with CORS enabled', (done) => {
+    it('should work with CORS enabled', async () => {
 
         server.route({
             method: 'GET',
             path: '/corstest',
-            handler: function (request, reply) {
+            handler: function (request, h) {
 
-                return reply('Testing CORS!');
+                return 'Testing CORS!';
             },
             config: {
                 cors: {
@@ -632,7 +513,7 @@ describe('Versioning', () => {
             }
         });
 
-        server.inject({
+        const response = await server.inject({
             method: 'OPTIONS',
             url: '/corstest',
             headers: {
@@ -640,299 +521,264 @@ describe('Versioning', () => {
                 'Access-Control-Request-Method': 'GET',
                 'Access-Control-Request-Headers': 'accept, authorization'
             }
-        }, (response) => {
+        });
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers).to.include({
+            'access-control-allow-origin': 'http://www.example.com'
+        });
 
-            expect(response.statusCode).to.equal(200);
-            expect(response.headers).to.include({
-                'access-control-allow-origin': 'http://www.example.com'
-            });
+        expect(response.headers).to.include('access-control-allow-methods');
+        expect(response.headers['access-control-allow-methods'].split(',')).to.include('GET');
 
-            expect(response.headers).to.include('access-control-allow-methods');
-            expect(response.headers['access-control-allow-methods'].split(',')).to.include('GET');
+        expect(response.headers).to.include('access-control-allow-headers');
+        expect(response.headers['access-control-allow-headers'].split(',')).to.include(['Accept', 'Authorization']);
+    });
+});
 
-            expect(response.headers).to.include('access-control-allow-headers');
-            expect(response.headers['access-control-allow-headers'].split(',')).to.include(['Accept', 'Authorization']);
+describe(' -> path parameters', () => {
 
-            done();
+    beforeEach(async () => {
+
+        await server.register({
+            plugin: require('../'),
+            options: {
+                validVersions: [0, 1, 2],
+                defaultVersion: 1,
+                vendorName: 'mysuperapi'
+            }
+        });
+        server.route({
+            method: 'GET',
+            path: '/unversioned/{catchAll*}',
+            handler: function (request, h) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: 'unversionedCatchAll'
+                };
+
+                return response;
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/versioned/{catchAll*3}',
+            handler: function (request, h) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: 'versionedCatchAll'
+                };
+
+                return response;
+            }
+        });
+
+
+        server.route({
+            method: 'GET',
+            path: '/unversioned/withPathParam/{unversionedPathParam}',
+            handler: function (request, h) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.unversionedPathParam
+                };
+
+                return response;
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v1/versioned/withPathParam/{versionedPathParam}',
+            handler: function (request, h) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.versionedPathParam
+                };
+
+                return response;
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/versioned/multiSegment/{segment*2}',
+            handler: function (request, h) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.segment
+                };
+
+                return response;
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/versioned/optionalPathParam/{optional?}',
+            handler: function (request, h) {
+
+                const response = {
+                    version: request.pre.apiVersion,
+                    data: request.params.optional
+                };
+
+                return response;
+            }
         });
     });
 
-    describe(' -> path parameters', () => {
+    it('resolves unversioned catch all routes', async () => {
 
-        beforeEach((done) => {
-
-            server.route({
-                method: 'GET',
-                path: '/unversioned/{catchAll*}',
-                handler: function (request, reply) {
-
-                    const response = {
-                        version: request.pre.apiVersion,
-                        data: 'unversionedCatchAll'
-                    };
-
-                    return reply(response);
-                }
-            });
-
-            server.route({
-                method: 'GET',
-                path: '/v2/versioned/{catchAll*}',
-                handler: function (request, reply) {
-
-                    const response = {
-                        version: request.pre.apiVersion,
-                        data: 'versionedCatchAll'
-                    };
-
-                    return reply(response);
-                }
-            });
-
-            server.route({
-                method: 'GET',
-                path: '/unversioned/withPathParam/{unversionedPathParam}',
-                handler: function (request, reply) {
-
-                    const response = {
-                        version: request.pre.apiVersion,
-                        data: request.params.unversionedPathParam
-                    };
-
-                    return reply(response);
-                }
-            });
-
-            server.route({
-                method: 'GET',
-                path: '/v1/versioned/withPathParam/{versionedPathParam}',
-                handler: function (request, reply) {
-
-                    const response = {
-                        version: request.pre.apiVersion,
-                        data: request.params.versionedPathParam
-                    };
-
-                    return reply(response);
-                }
-            });
-
-            server.route({
-                method: 'GET',
-                path: '/v2/versioned/multiSegment/{segment*2}',
-                handler: function (request, reply) {
-
-                    const response = {
-                        version: request.pre.apiVersion,
-                        data: request.params.segment
-                    };
-
-                    return reply(response);
-                }
-            });
-
-            server.route({
-                method: 'GET',
-                path: '/v2/versioned/optionalPathParam/{optional?}',
-                handler: function (request, reply) {
-
-                    const response = {
-                        version: request.pre.apiVersion,
-                        data: request.params.optional
-                    };
-
-                    return reply(response);
-                }
-            });
-
-            done();
+        const response = await server.inject({
+            method: 'GET',
+            url: '/unversioned/catch/all/route'
         });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(1);
+        expect(response.result.data).to.equal('unversionedCatchAll');
+    });
 
-        it('resolves unversioned catch all routes', (done) => {
+    it('resolves versioned catch all routes', async () => {
 
-            server.inject({
-                method: 'GET',
-                url: '/unversioned/catch/all/route'
-            }, (response) => {
+        const apiVersion = 2;
 
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal('unversionedCatchAll');
-
-                done();
-            });
+        const response = await server.inject({
+            method: 'GET',
+            url: '/versioned/catch/all/route',
+            headers: {
+                'api-version': apiVersion
+            }
         });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(apiVersion);
+        expect(response.result.data).to.equal('versionedCatchAll');
+    });
 
-        it('resolves versioned catch all routes', (done) => {
+    it('resolves unversioned routes with path parameters', async () => {
 
-            const apiVersion = 2;
+        const pathParam = '123456789';
 
-            server.inject({
-                method: 'GET',
-                url: '/versioned/catch/all/route',
-                headers: {
-                    'api-version': apiVersion
-                }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(apiVersion);
-                expect(response.result.data).to.equal('versionedCatchAll');
-
-                done();
-            });
+        const response = await server.inject({
+            method: 'GET',
+            url: '/unversioned/withPathParam/' + pathParam
         });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(1);
+        expect(response.result.data).to.equal(pathParam);
+    });
 
-        it('resolves unversioned routes with path parameters', (done) => {
+    it('resolves versioned routes with path parameters', async () => {
 
-            const pathParam = '123456789';
+        const pathParam = '123456789';
+        const apiVersion = 1;
 
-            server.inject({
-                method: 'GET',
-                url: '/unversioned/withPathParam/' + pathParam
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(1);
-                expect(response.result.data).to.equal(pathParam);
-
-                done();
-            });
+        const response = await server.inject({
+            method: 'GET',
+            url: '/versioned/withPathParam/' + pathParam,
+            headers: {
+                'api-version': apiVersion
+            }
         });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(apiVersion);
+        expect(response.result.data).to.equal(pathParam);
+    });
 
-        it('resolves versioned routes with path parameters', (done) => {
+    it('resolves multi segment path parameters', async () => {
 
-            const pathParam = '123456789';
-            const apiVersion = 1;
+        const apiVersion = 2;
+        const pathParam = 'multi/segment';
 
-            server.inject({
-                method: 'GET',
-                url: '/versioned/withPathParam/' + pathParam,
-                headers: {
-                    'api-version': apiVersion
-                }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(apiVersion);
-                expect(response.result.data).to.equal(pathParam);
-
-                done();
-            });
+        const response = await server.inject({
+            method: 'GET',
+            url: '/versioned/multiSegment/' + pathParam,
+            headers: {
+                'api-version': apiVersion
+            }
         });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(apiVersion);
+        expect(response.result.data).to.equal(pathParam);
+    });
 
-        it('resolves multi segment path parameters', (done) => {
+    it('resolves optional path parameters - without optional value', async () => {
 
-            const apiVersion = 2;
-            const pathParam = 'multi/segment';
+        const apiVersion = 2;
+        const pathParam = (server.version.indexOf('17.') > -1 ? '' : undefined);
 
-            server.inject({
-                method: 'GET',
-                url: '/versioned/multiSegment/' + pathParam,
-                headers: {
-                    'api-version': apiVersion
-                }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(apiVersion);
-                expect(response.result.data).to.equal(pathParam);
-
-                done();
-            });
+        const response = await server.inject({
+            method: 'GET',
+            url: '/versioned/optionalPathParam/',
+            headers: {
+                'api-version': apiVersion
+            }
         });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(apiVersion);
+        expect(response.result.data).to.equal(pathParam);
+    });
 
-        it('resolves optional path parameters - without optional value', (done) => {
+    it('resolves optional path parameters - with optional value', async () => {
 
-            const apiVersion = 2;
-            const pathParam = (server.version.indexOf('16.') > -1 ? '' : undefined);
+        const apiVersion = 2;
+        const pathParam = 'test';
 
-            server.inject({
-                method: 'GET',
-                url: '/versioned/optionalPathParam/',
-                headers: {
-                    'api-version': apiVersion
-                }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(apiVersion);
-                expect(response.result.data).to.equal(pathParam);
-
-                done();
-            });
+        const response = await server.inject({
+            method: 'GET',
+            url: '/versioned/optionalPathParam/' + pathParam,
+            headers: {
+                'api-version': apiVersion
+            }
         });
-
-        it('resolves optional path parameters - with optional value', (done) => {
-
-            const apiVersion = 2;
-            const pathParam = 'test';
-
-            server.inject({
-                method: 'GET',
-                url: '/versioned/optionalPathParam/' + pathParam,
-                headers: {
-                    'api-version': apiVersion
-                }
-            }, (response) => {
-
-                expect(response.statusCode).to.equal(200);
-                expect(response.result.version).to.equal(apiVersion);
-                expect(response.result.data).to.equal(pathParam);
-
-                done();
-            });
-        });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(apiVersion);
+        expect(response.result.data).to.equal(pathParam);
     });
 });
 
 describe('Versioning with passive mode', () => {
 
-    beforeEach((done) => {
+    beforeEach(async () => {
 
-        server.register([{
-            register: require('../'),
+        await server.register({
+            plugin: require('../'),
             options: {
                 validVersions: [1, 2],
                 defaultVersion: 1,
                 vendorName: 'mysuperapi',
                 passiveMode: true
             }
-        }], (err) => {
-
-            if (err) {
-                return console.error('Can not register plugins', err);
-            }
         });
 
         server.route({
             method: 'GET',
             path: '/unversioned',
-            handler: function (request, reply) {
+            handler: function (request, h) {
 
                 const response = {
                     data: 'unversioned'
                 };
 
-                return reply(response);
+                return response;
             }
         });
-
-        done();
     });
 
-    it('returns no version if no header is supplied', (done) => {
+    it('returns no version if no header is supplied', async () => {
 
-        server.inject({
+        const response = await server.inject({
             method: 'GET',
             url: '/unversioned'
-        }, (response) => {
-
-            expect(response.statusCode).to.equal(200);
-            expect(response.result.version).to.equal(undefined);
-            expect(response.result.data).to.equal('unversioned');
-
-            done();
         });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(undefined);
+        expect(response.result.data).to.equal('unversioned');
     });
 });
+


### PR DESCRIPTION
- [x] Updated the plugin to be fully compatible with async/wait. 

- [x] Used hapi master(now 17 version) branch for linking and testing.

- [x] Upgraded code and lab version to 5 and 15 above respectively. This helped in transitioning all the 
        test cases to async/wait compatible.

- [x] Bumped major version number to 2.0.0

- [x] Changed documentation and example code

Tested for hapi 17.1.1 application
node version 8.9.1
npm version 5.5.1