### PR TITLE
Admit more characters on the `Accept` header

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,16 @@ const _extractVersionFromAcceptHeader = function (request, options) {
     const acceptHeader = request.headers.accept;
     const media = MediaType.fromString(acceptHeader);
 
-    if (media.isValid() && (/^vnd.[a-zA-Z0-9]+\.v[0-9]+$/).test(media.subtype)) {
+    if (media.isValid() && (/^vnd.[a-z][a-z0-9.!#$&^_-]{0,126}\.v[0-9]+$/i).test(media.subtype)) {
 
-        if (media.subtypeFacets[1] !== options.vendorName) {
+        const vendorFacets = media.subtypeFacets.slice(1, media.subtypeFacets.length - 1);
+        const vendorName = vendorFacets.join('.');
+
+        if (vendorName !== options.vendorName) {
             return null;
         }
 
-        const version = media.subtypeFacets[2].replace('v', '');
+        const version = media.subtypeFacets[media.subtypeFacets.length - 1].slice(1);
 
         return parseInt(version);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -535,6 +535,49 @@ describe('Versioning', () => {
     });
 });
 
+describe(' -> vendor name ', () => {
+
+    beforeEach(async () => {
+
+        await server.register({
+            plugin: require('../'),
+            options: {
+                validVersions: [0, 1, 2],
+                defaultVersion: 1,
+                vendorName: 'my.super-Api!'
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v2/versioned',
+            handler: function (request, h) {
+
+                const response = {
+                    version: 2,
+                    data: 'versioned'
+                };
+
+                return response;
+            }
+        });
+    });
+
+    it('should accept non-alphanumeric characters', async () => {
+
+        const response = await server.inject({
+            method: 'GET',
+            url: '/versioned',
+            headers: {
+                'Accept': 'application/vnd.my.super-Api!.v2+json'
+            }
+        });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(2);
+        expect(response.result.data).to.equal('versioned');
+    });
+});
+
 describe(' -> path parameters', () => {
 
     beforeEach(async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -537,7 +537,7 @@ describe('Versioning', () => {
 
 describe(' -> vendor name ', () => {
 
-    beforeEach(async () => {
+    it('should accept non-alphanumeric characters', async () => {
 
         await server.register({
             plugin: require('../'),
@@ -561,9 +561,6 @@ describe(' -> vendor name ', () => {
                 return response;
             }
         });
-    });
-
-    it('should accept non-alphanumeric characters', async () => {
 
         const response = await server.inject({
             method: 'GET',
@@ -574,6 +571,43 @@ describe(' -> vendor name ', () => {
         });
         expect(response.statusCode).to.equal(200);
         expect(response.result.version).to.equal(2);
+        expect(response.result.data).to.equal('versioned');
+    });
+
+    it('should accept several period characters', async () => {
+
+        await server.register({
+            plugin: require('../'),
+            options: {
+                validVersions: [0, 1, 10],
+                defaultVersion: 1,
+                vendorName: 'company.departmanet.project.api'
+            }
+        });
+
+        server.route({
+            method: 'GET',
+            path: '/v10/versioned',
+            handler: function (request, h) {
+
+                const response = {
+                    version: 10,
+                    data: 'versioned'
+                };
+
+                return response;
+            }
+        });
+
+        const response = await server.inject({
+            method: 'GET',
+            url: '/versioned',
+            headers: {
+                'Accept': 'application/vnd.company.departmanet.project.api.v10+json'
+            }
+        });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(10);
         expect(response.result.data).to.equal('versioned');
     });
 });


### PR DESCRIPTION
This PR allows using more characters on the `Accept` header . Accepting those characters, means that now faceted names are available.

It follows the specification of https://tools.ietf.org/html/rfc6838#section-4.2.

Resolves https://github.com/p-meier/hapi-api-version/issues/21.