### PR TITLE
Prevent 500 errors on malformed CORS access-control-request-method headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,14 @@ exports.register = (server, options) => {
 
         const versionedPath = options.basePath + 'v' + requestedVersion + request.path.slice(options.basePath.length - 1);
 
-        const method = request.method === 'options' ? request.headers['access-control-request-method'] : request.method;
+        let method = request.method;
+        if (request.method === 'options') {
+            method = request.headers['access-control-request-method'];
+            if (!method) {
+                throw Boom.badRequest('The Access-Control-Request-Method header must be set for CORS requests.');
+            }
+        }
+
 
         const route = server.match(method, versionedPath);
 

--- a/test/index.js
+++ b/test/index.js
@@ -561,6 +561,15 @@ describe('Versioning', () => {
         });
         expect(response.statusCode).to.equal(400);
     });
+
+    it('handles invalid request methods properly', async () => {
+
+        const response = await server.inject({
+            method: 'FAKE',
+            url: '/route'
+        });
+        expect(response.statusCode).to.equal(404);
+    });
 });
 
 describe(' -> vendor name ', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -533,6 +533,34 @@ describe('Versioning', () => {
         expect(response.headers).to.include('access-control-allow-headers');
         expect(response.headers['access-control-allow-headers'].split(',')).to.include(['Accept', 'Authorization']);
     });
+
+    it('should 400 when an OPTIONS request has a malformed access-control-request-method header', async () => {
+
+        server.route({
+            method: 'GET',
+            path: '/corstest',
+            handler: function (request, h) {
+
+                return 'Testing CORS!';
+            },
+            config: {
+                cors: {
+                    origin: ['*'],
+                    headers: ['Accept', 'Authorization']
+                }
+            }
+        });
+
+        const response = await server.inject({
+            method: 'OPTIONS',
+            url: '/corstest',
+            headers: {
+                'Origin': 'http://www.example.com',
+                'Access-Control-Request-Method': ''
+            }
+        });
+        expect(response.statusCode).to.equal(400);
+    });
 });
 
 describe(' -> vendor name ', () => {


### PR DESCRIPTION
With the current implementation an `OPTIONS` request with a missing or empty `access-control-request-method` header triggers a 500 error due to https://github.com/hapijs/hapi/blob/f02cdf14560a22c27dc0b59f3efa93dcf06b3ffa/lib/server.js#L345.

This PR causes `hapi-api-version` to short circuit the call to `server.match` and responds with a 400.