### PR TITLE
Fix '/' endpoint and stripTrailingSlash compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,8 @@ exports.register = (server, options) => {
         if (typeof requestedVersion !== 'number') {
             requestedVersion = options.defaultVersion;
         }
-
-        const versionedPath = options.basePath + 'v' + requestedVersion + request.path.slice(options.basePath.length - 1);
+        const baseVersionedPath = options.basePath + 'v' + requestedVersion;
+        const versionedPath = baseVersionedPath + (request.path === '/' ? '' : request.path.slice(options.basePath.length - 1));
 
         let method = request.method;
         if (request.method === 'options') {
@@ -117,8 +117,9 @@ exports.register = (server, options) => {
 
         const route = server.match(method, versionedPath);
 
-        if (route && route.path.indexOf(options.basePath + 'v' + requestedVersion + '/') === 0) {
-            request.setUrl(options.basePath + 'v' + requestedVersion + request.url.path.slice(options.basePath.length - 1)); //required to preserve query parameters
+        if (route && route.path.indexOf(baseVersionedPath) === 0) {
+            const url = versionedPath + (request.url.search ? request.url.search : '');
+            request.setUrl(url); //required to preserve query parameters
         }
 
         //Set version for usage in handler

--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ exports.register = (server, options) => {
     options = validateOptions.value;
 
     server.ext('onRequest', (request, h) => {
-
         //First check for custom header
         let requestedVersion = _extractVersionFromCustomHeader(request, options);
 
@@ -103,8 +102,15 @@ exports.register = (server, options) => {
         if (typeof requestedVersion !== 'number') {
             requestedVersion = options.defaultVersion;
         }
+
         const baseVersionedPath = options.basePath + 'v' + requestedVersion;
-        const versionedPath = baseVersionedPath + (request.path === '/' ? '' : request.path.slice(options.basePath.length - 1));
+
+        const stripTrailingSlash = server.settings.router.stripTrailingSlash;
+        let versionedPath = baseVersionedPath + request.path.slice(options.basePath.length - 1);
+
+        if ( stripTrailingSlash === true) {
+            versionedPath = baseVersionedPath + (request.path === '/' ? '' : request.path.slice(options.basePath.length - 1));
+        }
 
         let method = request.method;
         if (request.method === 'options') {
@@ -113,7 +119,6 @@ exports.register = (server, options) => {
                 throw Boom.badRequest('The Access-Control-Request-Method header must be set for CORS requests.');
             }
         }
-
 
         const route = server.match(method, versionedPath);
 

--- a/test/index.js
+++ b/test/index.js
@@ -570,6 +570,47 @@ describe('Versioning', () => {
         });
         expect(response.statusCode).to.equal(404);
     });
+
+    it('handles rootPath and endpoint as "/" when using stripTrailingSlash', async () => {
+
+        const newServer = Hapi.server( { router: { stripTrailingSlash: true } } );
+        await newServer.start();
+
+        await newServer.register({
+            plugin: require('../'),
+            options: {
+                validVersions: [0, 1, 2],
+                defaultVersion: 1,
+                vendorName: 'mysuperapi'
+            }
+        });
+
+        newServer.route({
+            method: 'POST',
+            path: '/v2',
+            handler: function (request, h) {
+
+                const response = {
+                    version: 2,
+                    data: 'versioned'
+                };
+
+                return response;
+            }
+        });
+
+
+        const response = await newServer.inject( {
+            method: 'POST',
+            url: '/',
+            headers: {
+                'api-version': '2'
+            }
+        });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.version).to.equal(2);
+        expect(response.result.data).to.equal('versioned');
+    });
 });
 
 describe(' -> vendor name ', () => {


### PR DESCRIPTION
When using the server setting stripTrailingSlash and serving and endpoint at '/',
hapi-api-version would search for v2 at '/v2/'. This route is impossible when
stripTrailingSlash is set to true in Hapi, so the fallback default route would be served.
This patch adds a new test showing the issue and a fix so that '/' will serve at '/v2'.