### PR TITLE
Fix request.pre.apiVersion not being set when version is in route

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,16 @@ const _extractVersionFromAcceptHeader = function (request, options) {
     return null;
 };
 
+const _extractVersionFromPath = function (request, options) {
+
+    const versionedPathMatch = request.path.match(/^\/v(\d+)/);
+    if (versionedPathMatch) {
+        return parseInt(versionedPathMatch[1]);
+    }
+
+    return null;
+};
+
 //Set a response header containing the version number
 const _addVersionToResponseHeader = function (request, requestedVersion, options) {
 
@@ -87,6 +97,11 @@ exports.register = (server, options) => {
         //If no version check accept header
         if (typeof requestedVersion !== 'number') {
             requestedVersion = _extractVersionFromAcceptHeader(request, options);
+        }
+
+        //If no version check route path
+        if (typeof requestedVersion !== 'number') {
+            requestedVersion = _extractVersionFromPath(request, options);
         }
 
         //If passive mode skips the rest for non versioned routes

--- a/test/index.js
+++ b/test/index.js
@@ -260,7 +260,7 @@ describe('Versioning', () => {
                 handler: function (request, h) {
 
                     const response = {
-                        version: 1,
+                        version: request.pre.apiVersion,
                         data: 'versioned'
                     };
 
@@ -274,7 +274,7 @@ describe('Versioning', () => {
                 handler: function (request, h) {
 
                     const response = {
-                        version: 2,
+                        version: request.pre.apiVersion,
                         data: 'versioned'
                     };
 
@@ -319,6 +319,17 @@ describe('Versioning', () => {
                 headers: {
                     'Accept': 'application/vnd.mysuperapi.v2+json'
                 }
+            });
+            expect(response.statusCode).to.equal(200);
+            expect(response.result.version).to.equal(2);
+            expect(response.result.data).to.equal('versioned');
+        });
+
+        it('sets pre.apiVersion properly', async () => {
+
+            const response = await server.inject({
+                method: 'GET',
+                url: '/v2/versioned'
             });
             expect(response.statusCode).to.equal(200);
             expect(response.result.version).to.equal(2);


### PR DESCRIPTION
This PR resolves an issue where making a call to `/v2/versioned` was setting `request.pre.apiVersion` to `1` instead of `2`. 