### PR TITLE
2.3.0: Update dependencies to new hapi scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Register it with the server:
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const init = async function () {
     try {

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Hapi = require('hapi');
-const Joi = require('joi');
+const Hapi = require('@hapi/hapi');
+const Joi = require('@hapi/joi');
 
 const init = async function () {
 
@@ -102,7 +102,8 @@ const init = async function () {
     catch (err) {
         console.error(err);
         process.exit(1);
-    };
+    }
 };
+
 init();
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Boom = require('boom');
-const Hoek = require('hoek');
-const Joi = require('joi');
+const Boom = require('@hapi/boom');
+const Hoek = require('@hapi/hoek');
+const Joi = require('@hapi/joi');
 const MediaType = require('media-type');
 
 const Package = require('./package');
@@ -73,10 +73,12 @@ const _addVersionToResponseHeader = function (request, requestedVersion, options
     else {
         response.header(headerName, requestedVersion);
     }
+
     return;
 };
 
 exports.name = Package.name;
+
 exports.version = Package.version;
 
 exports.register = (server, options) => {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "hapi-api-version",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "An API versioning plugin for hapi.",
   "main": "index.js",
   "scripts": {
-    "test": "lab -a code -t 100 -L -v",
-    "test-coverage": "lab -c -a code -r html -o coverage/coverage.html"
+    "test": "lab -a @hapi/code -t 100 -L -v",
+    "test-coverage": "lab -c -a @hapi/code -r html -o coverage/coverage.html"
   },
   "repository": {
     "type": "git",
@@ -23,17 +23,17 @@
     "node": ">=8.0.0"
   },
   "peerDependencies": {
-    "hapi": ">=17.x.x"
+    "@hapi/hapi": "^18.3.1"
   },
   "devDependencies": {
-    "hapi": "17.x.x",
-    "code": "5.x.x",
-    "lab": "15.x.x"
+    "@hapi/hapi": "^18.3.1",
+    "@hapi/code": "^5.3.1",
+    "@hapi/lab": "^19.0.1"
   },
   "dependencies": {
-    "boom": "^5.2.0",
-    "hoek": "^4.2.0",
-    "joi": "^10.6.0",
-    "media-type": "^0.3.0"
+    "@hapi/boom": "^7.4.2",
+    "@hapi/hoek": "^6.2.3",
+    "@hapi/joi": "^15.0.3",
+    "media-type": "^0.3.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Hapi = require('hapi');
-const Code = require('code');
-const Lab = require('lab');
+const Hapi = require('@hapi/hapi');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
 
 const lab = exports.lab = Lab.script();
 
@@ -38,7 +38,7 @@ describe('Plugin registration', () => {
         }
         catch (e) {
             done();
-        };
+        }
     });
 
 


### PR DESCRIPTION
Hey,

I updated your hapi plugin since I need it. There is a problem with the tests code coverage but I think it comes from the update of lab.

![Coverage](https://i.imgur.com/pnwnE01.png)