### PR TITLE
Attempt url decoding before calling server.match

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,16 @@ const _addVersionToResponseHeader = function (request, requestedVersion, options
     return;
 };
 
+const _attemptPathDecoding = function (request) {
+
+    try {
+        decodeURI(request.path);
+    }
+    catch (err) {
+        throw Boom.badRequest('Invalid path');
+    }
+};
+
 exports.name = Package.name;
 exports.version = Package.version;
 
@@ -90,6 +100,8 @@ exports.register = (server, options) => {
     options = validateOptions.value;
 
     server.ext('onRequest', (request, h) => {
+        // Surface any URI decoding errors before calling server.match
+        _attemptPathDecoding(request);
 
         //First check for custom header
         let requestedVersion = _extractVersionFromCustomHeader(request, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-api-version",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "An API versioning plugin for hapi.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-api-version",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "An API versioning plugin for hapi.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The Hapi `server.match` method converts `badRequest` responses into Hoek assertion errors [1]. This causes malformed URLs to result in 500 errors in applications that use this plugin.

This fix attempts to decode the URI earlier and throws the appropriate `badRequest` error if it encounters any decoding errors.

[1] https://github.com/hapijs/hapi/blob/master/lib/server.js#L350

